### PR TITLE
update to 2.1.1 (resolves ubdcc-on-conda-forge blocker)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unicorn-binance-suite" %}
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 
 
 package:
@@ -8,24 +8,28 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 82dba608cf4e2b6cfb8d9a89c0b4cbf13b9f72c890d9bd3b227c4597665cdd96
+  sha256: b4f70c71fc484ad840409f31227a12c648bf5fc81ac49219575e12fe6fb342f4
 
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  # --no-deps because upstream setup.py also requires `ubdcc`, which is not
+  # available on conda-forge (by design — the UBDCC cluster ships as a PyPI
+  # package and Docker images only). Users who want the cluster client can
+  # `pip install ubdcc` into the same environment.
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python >=3.10
   run:
-    - python >=3.7
-    - unicorn-binance-local-depth-cache
-    - unicorn-binance-rest-api
-    - unicorn-binance-trailing-stop-loss
-    - unicorn-binance-websocket-api
-    - unicorn-fy
+    - python >=3.10
+    - unicorn-fy >=0.17.2
+    - unicorn-binance-rest-api >=2.11.0
+    - unicorn-binance-websocket-api >=2.12.2
+    - unicorn-binance-local-depth-cache >=2.12.2
+    - unicorn-binance-trailing-stop-loss >=1.3.1
 
 test:
   imports:
@@ -34,21 +38,20 @@ test:
     - unicorn_binance_trailing_stop_loss
     - unicorn_binance_websocket_api
     - unicorn_fy
-  commands:
-    - pip check
-  requires:
-    - pip
 
 about:
-  home: https://www.lucit.tech/unicorn-binance-suite.html
+  home: https://github.com/oliver-zehentleitner/unicorn-binance-suite
   summary: Suite of packages for creating automated trading systems with the Binance API.
   description: |
-    The UNICORN Binance Suite is a Python Meta Package of unicorn-fy, 
-    unicorn-binance-local-depth-cache, unicorn-binance-rest-api, unicorn-binance-trailing-stop-loss and unicorn-binance-websocket-api.
+    The UNICORN Binance Suite is a Python meta-package that bundles the suite modules
+    unicorn-fy, unicorn-binance-rest-api, unicorn-binance-websocket-api,
+    unicorn-binance-local-depth-cache and unicorn-binance-trailing-stop-loss.
+    The distributed depth-cache cluster (ubdcc) is not available on conda-forge; install
+    it separately via `pip install ubdcc` if needed.
   license: MIT
   license_file: LICENSE
-  dev_url: https://github.com/LUCIT-Systems-and-Development/unicorn-binance-suite
-  doc_url: https://unicorn-binance-suite.docs.lucit.tech
+  dev_url: https://github.com/oliver-zehentleitner/unicorn-binance-suite
+  doc_url: https://oliver-zehentleitner.github.io/unicorn-binance-suite
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
### Big update
This is the first meta-package bump since 1.1.0 (2.0.0 and 2.1.0 on PyPI never made it onto conda-forge). Resolves the blocker that caused those to be stuck.

### What changed
- Bump version 2.1.0 → 2.1.1, sha256 refreshed.
- Bump python floor `>=3.7` → `>=3.10` (conda-forge dropped Python 3.9 from the global pinning after py3.9 EOL in October 2025).
- Pin suite dep minimums to the cleanup-round releases:
  - `unicorn-fy >=0.17.2`
  - `unicorn-binance-rest-api >=2.11.0`
  - `unicorn-binance-websocket-api >=2.12.2`
  - `unicorn-binance-local-depth-cache >=2.12.2`
  - `unicorn-binance-trailing-stop-loss >=1.3.1`

### ubdcc handling (the reason 2.0.0 + 2.1.0 never built)
Upstream `setup.py` requires `ubdcc` as a hard dependency, but UBDCC (the distributed depth-cache cluster) is distributed as a PyPI package + Docker images and intentionally has **no conda-forge feedstock**. That deadlocked 2.0.0 / 2.1.0 here.

Resolution for this rebuild:
- Switch build script to `pip install . -vv --no-deps` so the missing ubdcc doesn't break the install step.
- Drop `pip check` from tests (it would flag the missing ubdcc even though the meta-package works fine for everything except the cluster client).
- ubdcc is called out in `about.description` as a `pip install ubdcc` add-on.

### Housekeeping
- `home`/`dev_url`/`doc_url` moved from `lucit.tech` / `LUCIT-Systems-and-Development` to the current upstream repo + github.io docs.

@conda-forge-admin, please rerender