### PR TITLE
Add setuptools + wheel to host (fix BackendUnavailable)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: b4f70c71fc484ad840409f31227a12c648bf5fc81ac49219575e12fe6fb342f4
 
 build:
-  number: 0
+  number: 1
   noarch: python
   # --no-deps because upstream setup.py also requires `ubdcc`, which is not
   # available on conda-forge (by design — the UBDCC cluster ships as a PyPI
@@ -23,6 +23,8 @@ requirements:
   host:
     - pip
     - python >=3.10
+    - setuptools
+    - wheel
   run:
     - python >=3.10
     - unicorn-fy >=0.17.2


### PR DESCRIPTION
The 2.1.1 main build failed with:

```
pip._vendor.pyproject_hooks._impl.BackendUnavailable:
    Cannot import 'setuptools.build_meta'
```

because the host environment only had `pip` + `python`. `pyproject.toml` declares `setuptools.build_meta` as the build backend, so `setuptools` must be present in host.

Added `setuptools` + `wheel` and bumped the build number to trigger a clean rebuild.