### PR TITLE
Cap python at <3.14 until suite deps have py3.14 variants

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: b4f70c71fc484ad840409f31227a12c648bf5fc81ac49219575e12fe6fb342f4
 
 build:
-  number: 1
+  number: 2
   noarch: python
   # --no-deps because upstream setup.py also requires `ubdcc`, which is not
   # available on conda-forge (by design — the UBDCC cluster ships as a PyPI
@@ -22,11 +22,11 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.10
+    - python >=3.10,<3.14
     - setuptools
     - wheel
   run:
-    - python >=3.10
+    - python >=3.10,<3.14
     - unicorn-fy >=0.17.2
     - unicorn-binance-rest-api >=2.11.0
     - unicorn-binance-websocket-api >=2.12.2


### PR DESCRIPTION
The 2.1.1 main build failed the test step with:

```
Unsatisfiable dependencies for platform linux-64: {MatchSpec("unicorn-binance-local-depth-cache[version='>=2.12.2']")}
├─ unicorn-binance-local-depth-cache >=2.12.2 * does not exist
├─ unicorn-binance-rest-api >=2.11.0 * does not exist
├─ unicorn-binance-trailing-stop-loss >=1.3.1 * does not exist
├─ unicorn-binance-websocket-api >=2.12.2 * does not exist
└─ unicorn-fy >=0.17.2 * does not exist
```

The packages **do exist** on conda-forge for py3.10–3.13 — but conda-build tests noarch packages against every Python in the global pinning, including 3.14. The suite sub-feedstocks haven't been migrated to py3.14 yet (open rerun requests: UBRA #27, UBWA #36, UBLDC #17, UBTSL #21).

Capping `python <3.14` here lets the meta-package build. The cap can be dropped once the sub-feedstocks have py3.14 variants.