### PR TITLE
Retry build (repodata was likely stale)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: b4f70c71fc484ad840409f31227a12c648bf5fc81ac49219575e12fe6fb342f4
 
 build:
-  number: 2
+  number: 3
   noarch: python
   # --no-deps because upstream setup.py also requires `ubdcc`, which is not
   # available on conda-forge (by design — the UBDCC cluster ships as a PyPI


### PR DESCRIPTION
Previous build failed the test solve with "unicorn-binance-local-depth-cache >=2.12.2 does not exist" — but all suite deps are in fact live on conda-forge across linux-64/osx-64/win-64 for py3.10–3.13. Looks like the channel repodata cache was stale when the previous build ran (it was minutes after UBLDC / UBTSL build_1 uploads).

Bumping build number to 3 to re-trigger.