### PR TITLE
Drop python <3.14 cap

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: b4f70c71fc484ad840409f31227a12c648bf5fc81ac49219575e12fe6fb342f4
 
 build:
-  number: 4
+  number: 5
   noarch: python
   # --no-deps because upstream setup.py also requires `ubdcc`, which is not
   # available on conda-forge (by design — the UBDCC cluster ships as a PyPI
@@ -22,11 +22,11 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.10,<3.14
+    - python >=3.10
     - setuptools
     - wheel
   run:
-    - python >=3.10,<3.14
+    - python >=3.10
     - unicorn-fy >=0.17.2
     - unicorn-binance-rest-api >=2.11.0
     - unicorn-binance-websocket-api >=2.12.2


### PR DESCRIPTION
The python upper bound was set to `<3.14` because the underlying suite
modules did not yet have py3.14 conda-forge packages. As of 2026-04-28
all 4 modules now have py314 packages live on linux-64 + osx-64 + win-64:

| Module | Version | py3.14 |
|--------|---------|--------|
| unicorn-binance-rest-api | 2.11.0 | ✓ |
| unicorn-binance-websocket-api | 2.12.2 | ✓ |
| unicorn-binance-local-depth-cache | 2.14.0 | ✓ |
| unicorn-binance-trailing-stop-loss | 1.3.1 | ✓ |
| unicorn-fy (transitive) | 0.17.2 | ✓ |

Dropping the cap lets noarch-python suite users install under py3.14.
Build number bumped to 5; suite-internal pins left untouched (constraints
are still on released versions, intentionally not bumped reflexively).